### PR TITLE
690 Fixed userAds in paths.js

### DIFF
--- a/frontend/src/utils/paths.js
+++ b/frontend/src/utils/paths.js
@@ -6,7 +6,7 @@ const paths = {
   newAd: '/new-ad',
   profile: '/profile',
   register: '/register',
-  userAds: '/user-ads',
+  userAds: '/ads',
   userAdmin: '/lista-usuarios-admins',
 }
 


### PR DESCRIPTION
The path for 'AdList' in App.jsx had been changed but the direction in paths.js wasn't.

Changed 'userAds' from '/user-ads' to '/ads' to match the new path.