### PR TITLE
511 add change password page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,7 +28,7 @@ function App() {
       <Route exact path="/new-ad" component={CreateNewAd} />
       <Route exact path={paths.login} component={Login} />
       <Route exact path={paths.register} component={Registration} />
-      <Route exact path="/recover-password" component={RecoverPassword} />
+      <Route exact path={paths.recoverPassword} component={RecoverPassword} />
       <Route exact path="/students" component={Students} />
       <Route exact path="/business" component={Business} />
       <ProtectedRoute exact path={paths.profile} component={Profile} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,10 +28,11 @@ function App() {
       <Route exact path="/new-ad" component={CreateNewAd} />
       <Route exact path={paths.login} component={Login} />
       <Route exact path={paths.register} component={Registration} />
+      <Route exact path="/recover-password" component={RecoverPassword} />
       <Route exact path="/students" component={Students} />
       <Route exact path="/business" component={Business} />
       <ProtectedRoute exact path={paths.profile} component={Profile} />
-      <ProtectedRoute exact path="/recover-password" component={RecoverPassword} />
+      {/* <ProtectedRoute exact path="/recover-password" component={RecoverPassword} /> */}
       <ProtectedRoute exact path="/ads" component={AdList} />
       <ProtectedRoute exact path={paths.userAdmin} component={ListaUsuariosAdmins} />
       <ProtectedRoute exact path="/dashboard" component={Dashboard} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -32,7 +32,6 @@ function App() {
       <Route exact path="/students" component={Students} />
       <Route exact path="/business" component={Business} />
       <ProtectedRoute exact path={paths.profile} component={Profile} />
-      {/* <ProtectedRoute exact path="/recover-password" component={RecoverPassword} /> */}
       <ProtectedRoute exact path="/ads" component={AdList} />
       <ProtectedRoute exact path={paths.userAdmin} component={ListaUsuariosAdmins} />
       <ProtectedRoute exact path="/dashboard" component={Dashboard} />

--- a/frontend/src/pages/UserFlow/RecoverPassword/RecoverPassword.jsx
+++ b/frontend/src/pages/UserFlow/RecoverPassword/RecoverPassword.jsx
@@ -22,15 +22,7 @@ import Text from '../../../components/atoms/Text'
 function RecoverPassword() {
   const [animatedState, setAnimatedState] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  // part of state
   const dispatch = useDispatch()
-
-  // hook(custom)=> -optional argument: resolver(function:allows you to use any external validation library such as Yup)
-  //                -deconstruction:
-  //                  ·register(method):register an input and apply validation rules to React Hook Form.
-  //                  ·handleSubmit(function):will receive the form data if form validation is successful.
-  //                  ·formstate(object):holds info about the entire form state
-  //                    {errors}(object):An object with field errors. There is also an ErrorMessage component to retrieve error message easily.
   const {
     register,
     handleSubmit,
@@ -40,8 +32,8 @@ function RecoverPassword() {
   })
 
   const submitForm = (data) => {
-    // const { email } = data
-    sendEmail(data)
+    const { email } = data
+    sendEmail(email)
   }
 
   const sendEmail = async (data) => {
@@ -53,10 +45,7 @@ function RecoverPassword() {
     }, 2000)
 
     try {
-      // Given a module you can access meta information about the module using the import.meta
-      // It returns an object with a url property indicating the base URL of the module
       await axios.post(`${import.meta.env.VITE_API_URL}/recover-password`, data)
-      // await axios.post(`${process.env.VITE_API_URL}/recover-password`, dataEmail)
       dispatch(
         newNotification({
           message: 'The instructions to recover your password has been sent to your email',

--- a/frontend/src/pages/UserFlow/RecoverPassword/RecoverPassword.jsx
+++ b/frontend/src/pages/UserFlow/RecoverPassword/RecoverPassword.jsx
@@ -22,8 +22,15 @@ import Text from '../../../components/atoms/Text'
 function RecoverPassword() {
   const [animatedState, setAnimatedState] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  // part of state
   const dispatch = useDispatch()
 
+  // hook(custom)=> -optional argument: resolver(function:allows you to use any external validation library such as Yup)
+  //                -deconstruction:
+  //                  ·register(method):register an input and apply validation rules to React Hook Form.
+  //                  ·handleSubmit(function):will receive the form data if form validation is successful.
+  //                  ·formstate(object):holds info about the entire form state
+  //                    {errors}(object):An object with field errors. There is also an ErrorMessage component to retrieve error message easily.
   const {
     register,
     handleSubmit,
@@ -33,11 +40,11 @@ function RecoverPassword() {
   })
 
   const submitForm = (data) => {
-    const { email } = data
-    sendEmail(email)
+    // const { email } = data
+    sendEmail(data)
   }
 
-  const sendEmail = async (email) => {
+  const sendEmail = async (data) => {
     setAnimatedState(true)
     setIsLoading(true)
     setTimeout(() => {
@@ -46,8 +53,10 @@ function RecoverPassword() {
     }, 2000)
 
     try {
-      await axios.post(`${import.meta.env.VITE_API_URL}/recover-password`, email)
-      // await axios.post(`${process.env.VITE_API_URL}/recover-password`, email)
+      // Given a module you can access meta information about the module using the import.meta
+      // It returns an object with a url property indicating the base URL of the module
+      await axios.post(`${import.meta.env.VITE_API_URL}/recover-password`, data)
+      // await axios.post(`${process.env.VITE_API_URL}/recover-password`, dataEmail)
       dispatch(
         newNotification({
           message: 'The instructions to recover your password has been sent to your email',
@@ -72,7 +81,7 @@ function RecoverPassword() {
             text={
               <>
                 <b>¿Has olvidado tu contraseña?</b> Para recuperarla introduce tu email y te
-                enviaremos una nueva por correo.{' '}
+                enviaremos una nueva por correo.
               </>
             }
           />

--- a/frontend/src/pages/UserFlow/RecoverPassword/RecoverPassword.jsx
+++ b/frontend/src/pages/UserFlow/RecoverPassword/RecoverPassword.jsx
@@ -17,6 +17,7 @@ import { Container, Form } from '../UserFlow.styles'
 // Form validation
 import recoverPasswordSchema from '../../../validation/recoverPasswordSchema'
 import { newNotification, NotificationTypes } from '../../../store/notificationSlice'
+import Text from '../../../components/atoms/Text'
 
 function RecoverPassword() {
   const [animatedState, setAnimatedState] = useState(false)
@@ -66,10 +67,18 @@ function RecoverPassword() {
     <Body title="Cambiar contraseña" justifyTitle="center">
       <Container>
         <Form onSubmit={handleSubmit(submitForm)} noValidation>
+          <Text
+            text={
+              <>
+                <b>¿Has olvidado tu contraseña?</b> Para recuperarla introduce tu email y te
+                enviaremos una nueva por correo.{' '}
+              </>
+            }
+          />
           <Input
             type="email"
             name="email"
-            placeholder="enter your email"
+            placeholder="Email"
             register={register('email')}
             error={errors.email?.message}
           />
@@ -78,7 +87,7 @@ function RecoverPassword() {
             loadingText="Enviando"
             iconPosition="left"
             type="submit"
-            className="w-full blue-gradient mt-6"
+            className="w-full orange-gradient mt-6 shadow-lg"
             isLoading={isLoading}
             animated={animatedState}
           />

--- a/frontend/src/pages/UserFlow/RecoverPassword/RecoverPassword.jsx
+++ b/frontend/src/pages/UserFlow/RecoverPassword/RecoverPassword.jsx
@@ -47,6 +47,7 @@ function RecoverPassword() {
 
     try {
       await axios.post(`${import.meta.env.VITE_API_URL}/recover-password`, email)
+      // await axios.post(`${process.env.VITE_API_URL}/recover-password`, email)
       dispatch(
         newNotification({
           message: 'The instructions to recover your password has been sent to your email',

--- a/frontend/src/utils/paths.js
+++ b/frontend/src/utils/paths.js
@@ -8,6 +8,7 @@ const paths = {
   register: '/register',
   userAds: '/ads',
   userAdmin: '/lista-usuarios-admins',
+  recoverPassword: '/recover-password',
 }
 
 export default paths


### PR DESCRIPTION
Displaying change password page.  
Missing from backend:
-On requesting  'recover-password', a 'status 500 error' appears on console:
POST http://localhost:10910/api/v1/recover-password 500 (Internal Server Error)
-On the fetch/XHR 'recover-password': 
 message : "\nInvalid `prisma.user.findUnique()` 

linked to issue # 721 Fix recover password request on ITA-API

